### PR TITLE
fix: geoloniaではlocalhost, github.ioではYOUR-API-KEY文字列指定で無制限に使えるとのこと

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,4 @@
 NODE_ENV='local'
-VUE_APP_GEOLONIA_API_KEY='xxxxxxxxxxxxxxxxxxxxxxxxxxx'
+VUE_APP_GEOLONIA_API_KEY=YOUR-API-KEY
 VUE_APP_GEOJSON_BASE='https://raw.githubusercontent.com/terukizm/goto-eater-data/main/data/output'
 VUE_APP_GOOGLE_ANALYTICS_ID='xxxxxxxxxxxxxxxxxxxxxxxxxxx'

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ $ git clone git@github.com:terukizm/goto-eater.git
 $ cd goto-eater/
 
 $ cp .env.local.example .env.local
-$ vi .env.local
+(Geoloniaはlocalhost, github.ioからであれば`YOUR_API_KEY`文字列を指定すると制限なく試用可能とのこと)
 ---
-VUE_APP_GEOLONIA_API_KEY='xxxxxxxxxxxxxxxxxxxxxxxxxxx'
+VUE_APP_GEOLONIA_API_KEY=YOUR_API_KEY
 ---
 
 $ npm install


### PR DESCRIPTION
production側もリリースがGitHub Pagesなので、同様に`YOUR_API_KEY`で良いのですが、
まあなんかのときにAPI_KEYを止めることで対処できるからいいだろ…って感じでそのままにしてあります。